### PR TITLE
Stop "hacking" and deleting files in TS3dir ...

### DIFF
--- a/sinusbot.service
+++ b/sinusbot.service
@@ -11,6 +11,7 @@ WorkingDirectory=YOURPATH_TO_THE_BOT_DIRECTORY
 Type=simple
 KillSignal=2
 SendSIGKILL=yes
+Environment=QT_XCB_GL_INTEGRATION=none
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Deutsch:
Durch setzten der QT_XCB_GL_INTEGRATION auf none wird das QT Framework angewiesen GLX zu überspringen.
Durch setzen dieser Environment Variable direkt beim Starten über den systemd kann bei Teamspeak Client Versionen neuer 3.1.x (getestet mit der neusten 3.1.7) das Löschen der libqxcb-glx-integration.so vermieden werden.
Sorgt für eine Fehlerquelle weniger bei einem Update ;)
Bei den neueren Teamspeak Version kann hierdurch außerdem auch Arbeitsspeicher gespart werden :)

Ältere Teamspeak Clients <3.1.x sind nicht beeinflusst von der Variable und laufen weiterhin ohne Probleme

English:
By setting the environment variable QT_XCB_GL_INTEGRATION to none the qt framework will be advised to skip loading of GLK.
Through setting the environment variable direct at systemd startup, you can avoid deleting the libqxcb-glx-integration.so file while using a Teamspeak client version newer 3.1.x (tested with 3.1.7).
Provides less errors on an update.
With newer Teamspeak Versions you save also ram with this.

Older Teamspeak clients <3.1.x are not influenced by the variable and will run furthermore without problems.