### PR TITLE
Only run if ts3server is already up

### DIFF
--- a/sinusbot.service
+++ b/sinusbot.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Sinusbot, the Teamspeak 3 and Discord music bot.
+Requires=ts3server.service
 Wants=network-online.target
 After=syslog.target network.target network-online.target
 

--- a/sinusbot.service
+++ b/sinusbot.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Sinusbot, the Teamspeak 3 and Discord music bot.
-Requires=ts3server.service
+#Requires=ts3server.service
 Wants=network-online.target
 After=syslog.target network.target network-online.target
 


### PR DESCRIPTION
This prevents situations where sinusbot is started before ts3 server is up and instances won't be able to connect.